### PR TITLE
replace fuzzywuzzy with rapidfuzz

### DIFF
--- a/archivessnake/edit_notes.py
+++ b/archivessnake/edit_notes.py
@@ -7,7 +7,8 @@ import os
 import time
 
 from asnake.aspace import ASpace
-from fuzzywuzzy import fuzz
+#from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 config = ConfigParser()
 config.read("local_settings.cfg")


### PR DESCRIPTION
@kemartin2015 I didn't end up having to change the confidence ratio when testing rapidfuzz on my end - things were working as expected. Perhaps you can test it a few times on your end just to make sure it is, in fact, as simple as switching the module names?