### PR TITLE
Update orphan containers logic

### DIFF
--- a/archivessnake/delete_orphan_containers.py
+++ b/archivessnake/delete_orphan_containers.py
@@ -10,6 +10,7 @@ import configparser
 import json
 
 from asnake.aspace import ASpace
+from datetime import date
 
 
 class ContainerDeleter:
@@ -20,10 +21,13 @@ class ContainerDeleter:
         self.repo = self.aspace.repositories(config.get('ArchivesSpace', 'repository'))
 
     def run(self):
+        n = 0
         for container in self.repo.search.with_params(q="types:top_container AND empty_u_sbool:true", all_ids=True):
             deleted = self.aspace.client.delete(container.uri)
             print(container.uri)
-            with open('deleted.txt', 'w') as out_file:
-                out_file.write(json.dumps(out))
+            n += 1
+        with open('deleted.txt', 'a') as out_file:
+            today = str(date.today())
+            out_file.write("Deleted {} top containers on {}.\n".format(n, today))
 
 ContainerDeleter().run()

--- a/archivessnake/delete_orphan_containers.py
+++ b/archivessnake/delete_orphan_containers.py
@@ -8,9 +8,9 @@ usage: python delete_orphan_containers.py
 
 import configparser
 import json
+from datetime import date
 
 from asnake.aspace import ASpace
-from datetime import date
 
 
 class ContainerDeleter:
@@ -21,13 +21,13 @@ class ContainerDeleter:
         self.repo = self.aspace.repositories(config.get('ArchivesSpace', 'repository'))
 
     def run(self):
-        n = 0
+        delete_count = 0
         for container in self.repo.search.with_params(q="types:top_container AND empty_u_sbool:true", all_ids=True):
             deleted = self.aspace.client.delete(container.uri)
             print(container.uri)
-            n += 1
+            delete_count += 1
         with open('deleted.txt', 'a') as out_file:
             today = str(date.today())
-            out_file.write("Deleted {} top containers on {}.\n".format(n, today))
+            out_file.write("Deleted {} top containers on {}.\n".format(delete_count, today))
 
 ContainerDeleter().run()


### PR DESCRIPTION
Iterates up a count for deleting orphan containers. Moves write method outside of for loop.

Changes file open to append mode to avoid overwriting file. Includes today's date for counting purposes.